### PR TITLE
Update to Jakarta EE libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,9 @@
 
   <properties>
     <!-- Java & Framework Versions -->
-    <jdk.version>1.8</jdk.version>
-    <spring.version>5.1.2.RELEASE</spring.version>
+    <jdk.version>17</jdk.version>
+    <!-- Spring Framework version compatible with Jakarta EE -->
+    <spring.version>6.1.2</spring.version>
     <junit.version>4.13.2</junit.version>
     <log4j.version>1.2.17</log4j.version>
 
@@ -80,16 +81,16 @@
     </dependency>
     <!-- JSTL for JSP pages -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
-      <version>1.2</version>
+      <groupId>jakarta.servlet.jsp.jstl</groupId>
+      <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+      <version>3.0.0</version>
     </dependency>
 
     <!-- Servlet API (provided) -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/com/mt/config/DatabaseConfig.java
+++ b/src/main/java/com/mt/config/DatabaseConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
-import javax.sql.DataSource;
+import jakarta.sql.DataSource;
 
 @Configuration
 public class DatabaseConfig {

--- a/src/main/webapp/WEB-INF/views/enquiry.jsp
+++ b/src/main/webapp/WEB-INF/views/enquiry.jsp
@@ -1,5 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html lang="en">
 <head>
   <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- upgrade to JDK17 and Spring 6
- switch servlet & JSTL dependencies to jakarta packages
- update taglib URIs
- adjust `DatabaseConfig` for `jakarta.sql.DataSource`

