### PR TITLE
Fix DataSource import and align WAR naming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Use Tomcat as base image from docker official
-FROM tomcat:9.0-jdk8-openjdk
+FROM tomcat:10.1-jdk17-temurin
 
 # Remove default ROOT webapp
 RUN rm -rf /usr/local/tomcat/webapps/ROOT
 
 # Copy the WAR file to Tomcat
-COPY target/range-rover.war /usr/local/tomcat/webapps/ROOT.war
+COPY target/tesco.war /usr/local/tomcat/webapps/ROOT.war
 
 # Expose port
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Before diving in, ensure you have:
 mvn clean install
 ````
 
-Creates `target/range-rover.war`.
+Creates `target/tesco.war`.
 
 > Use `mvn clean verify` for strict, CI-friendly builds.
 
@@ -140,9 +140,9 @@ mvn deploy
 ### Dockerfile
 
 ```Dockerfile
-FROM tomcat:9.0-jdk8-openjdk
+FROM tomcat:10.1-jdk17-temurin
 RUN rm -rf /usr/local/tomcat/webapps/*
-COPY target/range-rover.war /usr/local/tomcat/webapps/ROOT.war
+COPY target/tesco.war /usr/local/tomcat/webapps/ROOT.war
 EXPOSE 8080
 CMD ["catalina.sh", "run"]
 ```

--- a/k8s-deployment.yaml
+++ b/k8s-deployment.yaml
@@ -14,9 +14,9 @@ spec:
       labels:
         app: devops-academy
     spec:
-      containers:
-        - name: webapp
-          image: <your-dockerhub-username>/range-rover:latest
+        containers:
+          - name: webapp
+            image: <your-dockerhub-username>/tesco:latest
           env:
             - name: DB_URL
               value: jdbc:postgresql://postgres:5432/postgres

--- a/src/main/java/com/mt/config/DatabaseConfig.java
+++ b/src/main/java/com/mt/config/DatabaseConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
-import jakarta.sql.DataSource;
+import javax.sql.DataSource;
 
 @Configuration
 public class DatabaseConfig {


### PR DESCRIPTION
## Summary
- use `javax.sql.DataSource` for DatabaseConfig
- base Docker image on Tomcat 10 and copy `tesco.war`
- update README instructions for the WAR and Dockerfile
- update Kubernetes deployment image reference

