### PR TITLE
Fix Tomcat 9 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Tomcat as base image from docker official
-FROM tomcat:10.1-jdk17-temurin
+FROM tomcat:9.0-jdk17-temurin
 
 # Remove default ROOT webapp
 RUN rm -rf /usr/local/tomcat/webapps/ROOT

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ mvn deploy
 ### Dockerfile
 
 ```Dockerfile
-FROM tomcat:10.1-jdk17-temurin
+FROM tomcat:9.0-jdk17-temurin
 RUN rm -rf /usr/local/tomcat/webapps/*
 COPY target/tesco.war /usr/local/tomcat/webapps/ROOT.war
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -81,16 +81,16 @@
     </dependency>
     <!-- JSTL for JSP pages -->
     <dependency>
-      <groupId>jakarta.servlet.jsp.jstl</groupId>
-      <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-      <version>3.0.0</version>
+      <groupId>javax.servlet</groupId>
+      <artifactId>jstl</artifactId>
+      <version>1.2</version>
     </dependency>
 
     <!-- Servlet API (provided) -->
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.0.0</version>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/webapp/WEB-INF/views/enquiry.jsp
+++ b/src/main/webapp/WEB-INF/views/enquiry.jsp
@@ -1,5 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <html lang="en">
 <head>
   <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- switch Dockerfile back to Tomcat 9
- reference Tomcat 9 in README Dockerfile snippet
- revert pom.xml to use javax servlet APIs
- update JSP pages to use the classic JSTL URI

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f9716548c832fa30e3ffdb3fc6241