### PR TITLE
Update servlet dependencies to Jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,16 +81,21 @@
     </dependency>
     <!-- JSTL for JSP pages -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
-      <version>1.2</version>
+      <groupId>jakarta.servlet.jsp.jstl</groupId>
+      <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.web</groupId>
+      <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+      <version>3.0.0</version>
     </dependency>
 
     <!-- Servlet API (provided) -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
## Summary
- use Jakarta Servlet 6.0 and JSTL 3.0 dependencies

